### PR TITLE
Update default settings to 7-day PR reviews

### DIFF
--- a/src/components/LeaderboardChart.tsx
+++ b/src/components/LeaderboardChart.tsx
@@ -44,14 +44,14 @@ export default function LeaderboardChart() {
 
   const debouncedDisplayDateRange = useDebounce(displayDateRange, 300);
 
-  const [viewType, setViewType] = useState<MaterializedViewType>('monthly');
+  const [viewType, setViewType] = useState<MaterializedViewType>('weekly');
   const [selectedTools, setSelectedTools] = useState<Set<number>>(new Set());
   const prevToolKeysRef = useRef<string[]>([]);
   const [scaleType, setScaleType] = useState<'linear' | 'log'>('linear');
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [toolSearchQuery, setToolSearchQuery] = useState<string>('');
   const [metric, setMetric] = useState<'active_repos' | 'pr_reviews'>(
-    'active_repos'
+    'pr_reviews'
   );
 
   const baseUrl =


### PR DESCRIPTION
Change the default UI settings to a 7-day window and PR reviews metric.

---
<a href="https://cursor.com/background-agent?bcId=bc-c96d7133-edea-41d4-89cf-713c954efeba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c96d7133-edea-41d4-89cf-713c954efeba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

