### PR TITLE
Update default settings to 7-day PR reviews

### DIFF
--- a/src/components/LeaderboardChart.tsx
+++ b/src/components/LeaderboardChart.tsx
@@ -44,14 +44,14 @@ export default function LeaderboardChart() {
 
   const debouncedDisplayDateRange = useDebounce(displayDateRange, 300);
 
-  const [viewType, setViewType] = useState<MaterializedViewType>('monthly');
+  const [viewType, setViewType] = useState<MaterializedViewType>('weekly');
   const [selectedTools, setSelectedTools] = useState<Set<number>>(new Set());
   const prevToolKeysRef = useRef<string[]>([]);
   const [scaleType, setScaleType] = useState<'linear' | 'log'>('linear');
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [toolSearchQuery, setToolSearchQuery] = useState<string>('');
   const [metric, setMetric] = useState<'active_repos' | 'pr_reviews'>(
-    'active_repos'
+    'pr_reviews'
   );
 
   const baseUrl =

--- a/src/components/LeaderboardChartSkeleton.tsx
+++ b/src/components/LeaderboardChartSkeleton.tsx
@@ -25,9 +25,9 @@ const LeaderboardChartSkeleton: React.FC = () => {
         <CardHeader>
           <div className="flex flex-col gap-2">
             <div>
-              <CardTitle className="mb-2">Active Repositories</CardTitle>
+              <CardTitle className="mb-2">PR Reviews</CardTitle>
               <CardDescription className="text-xs">
-                Repos with an AI code review, 30-day rolling window.
+                Number of PR reviews by AI code review bots, 7-day rolling window.
               </CardDescription>
             </div>
             {/* Control Bar Skeleton */}
@@ -61,7 +61,7 @@ const LeaderboardChartSkeleton: React.FC = () => {
               </div>
               {/* Window Size Section */}
               <div className="flex items-center gap-2">
-                <WindowToggle value="monthly" onChange={() => {}} />
+                <WindowToggle value="weekly" onChange={() => {}} />
               </div>
               {/* Scale Section */}
               <div className="flex items-center gap-2">


### PR DESCRIPTION
Change default leaderboard settings to 7-day and PR reviews to align with user preferences.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3c05e3c-4727-4e27-b5f4-f83adebdfa77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3c05e3c-4727-4e27-b5f4-f83adebdfa77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> This PR updates the default view on the leaderboard to show weekly PR reviews instead of monthly active repositories.
> 
> - **Leaderboard Defaults**:
>   - In `src/components/LeaderboardChart.tsx`, the default `metric` is changed from `'active_repos'` to `'pr_reviews'`, and the default `viewType` is changed from `'monthly'` to `'weekly'`.
>   - The `src/components/LeaderboardChartSkeleton.tsx` is updated to match these new defaults, changing the title to "PR Reviews", updating the description, and setting the `WindowToggle` default to `'weekly'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be8fa215ec7140b2e599c918fe4a5bc7b790e572. This will update automatically on new commits.</sup>
<!-- /CURSOR_SUMMARY -->