### PR TITLE
Update default settings to 7-day PR reviews

### DIFF
--- a/src/components/LeaderboardChart.tsx
+++ b/src/components/LeaderboardChart.tsx
@@ -44,14 +44,14 @@ export default function LeaderboardChart() {
 
   const debouncedDisplayDateRange = useDebounce(displayDateRange, 300);
 
-  const [viewType, setViewType] = useState<MaterializedViewType>('monthly');
+  const [viewType, setViewType] = useState<MaterializedViewType>('weekly');
   const [selectedTools, setSelectedTools] = useState<Set<number>>(new Set());
   const prevToolKeysRef = useRef<string[]>([]);
   const [scaleType, setScaleType] = useState<'linear' | 'log'>('linear');
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [toolSearchQuery, setToolSearchQuery] = useState<string>('');
   const [metric, setMetric] = useState<'active_repos' | 'pr_reviews'>(
-    'active_repos'
+    'pr_reviews'
   );
 
   const baseUrl =

--- a/src/components/LeaderboardChartSkeleton.tsx
+++ b/src/components/LeaderboardChartSkeleton.tsx
@@ -27,7 +27,8 @@ const LeaderboardChartSkeleton: React.FC = () => {
             <div>
               <CardTitle className="mb-2">PR Reviews</CardTitle>
               <CardDescription className="text-xs">
-                Number of PR reviews by AI code review bots, 7-day rolling window.
+                Number of PR reviews by AI code review bots, 7-day rolling
+                window.
               </CardDescription>
             </div>
             {/* Control Bar Skeleton */}
@@ -104,7 +105,9 @@ const LeaderboardChartSkeleton: React.FC = () => {
         <CardHeader>
           <div className="flex items-center justify-between w-full">
             <CardTitle className="">Current Rankings</CardTitle>
-            <span className="text-xs text-muted-foreground pr-2">PR Reviews</span>
+            <span className="text-xs text-muted-foreground pr-2">
+              PR Reviews
+            </span>
           </div>
           <CardDescription className="text-xs">
             There were ... PR reviews by AI code review bots last week.

--- a/src/components/LeaderboardChartSkeleton.tsx
+++ b/src/components/LeaderboardChartSkeleton.tsx
@@ -25,9 +25,9 @@ const LeaderboardChartSkeleton: React.FC = () => {
         <CardHeader>
           <div className="flex flex-col gap-2">
             <div>
-              <CardTitle className="mb-2">Active Repositories</CardTitle>
+              <CardTitle className="mb-2">PR Reviews</CardTitle>
               <CardDescription className="text-xs">
-                Repos with an AI code review, 30-day rolling window.
+                Number of PR reviews by AI code review bots, 7-day rolling window.
               </CardDescription>
             </div>
             {/* Control Bar Skeleton */}
@@ -61,7 +61,7 @@ const LeaderboardChartSkeleton: React.FC = () => {
               </div>
               {/* Window Size Section */}
               <div className="flex items-center gap-2">
-                <WindowToggle value="monthly" onChange={() => {}} />
+                <WindowToggle value="weekly" onChange={() => {}} />
               </div>
               {/* Scale Section */}
               <div className="flex items-center gap-2">
@@ -104,12 +104,10 @@ const LeaderboardChartSkeleton: React.FC = () => {
         <CardHeader>
           <div className="flex items-center justify-between w-full">
             <CardTitle className="">Current Rankings</CardTitle>
-            <span className="text-xs text-muted-foreground pr-2">
-              Active Repos
-            </span>
+            <span className="text-xs text-muted-foreground pr-2">PR Reviews</span>
           </div>
           <CardDescription className="text-xs">
-            There were ... public repos with pull requests last month.
+            There were ... PR reviews by AI code review bots last week.
           </CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
Update default UI settings to show 7-day window and PR reviews instead of 30-day and active repos.

---
<a href="https://cursor.com/background-agent?bcId=bc-f92fa6ee-783b-4148-87dc-bbf44a857b3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f92fa6ee-783b-4148-87dc-bbf44a857b3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

