### PR TITLE
Update LeaderboardChart.tsx - active repos as default

### DIFF
--- a/src/components/LeaderboardChart.tsx
+++ b/src/components/LeaderboardChart.tsx
@@ -51,7 +51,7 @@ export default function LeaderboardChart() {
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [toolSearchQuery, setToolSearchQuery] = useState<string>('');
   const [metric, setMetric] = useState<'active_repos' | 'pr_reviews'>(
-    'pr_reviews'
+    'active_repos'
   );
 
   const baseUrl =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Changes the default metric displayed on the leaderboard chart from 'PR Reviews' to 'Active Repos'.
> 
> - **Default Metric Change**
>     - The initial value for the `metric` state in `src/components/LeaderboardChart.tsx` has been updated.
>     - The leaderboard chart will now default to displaying 'Active Repos' data instead of 'PR Reviews' data upon initial load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 162d1007a8d772a0993ddf27717a5cc4bede3dea. It will update automatically on new commits.</sup>
<!-- /CURSOR_SUMMARY -->

___
# Cursor summary

Changes the default metric displayed on the leaderboard chart from 'PR Reviews' to 'Active Repos'.

- **Default Metric Change**
    - The initial value for the `metric` state in `src/components/LeaderboardChart.tsx` has been updated.
    - The leaderboard chart will now default to displaying 'Active Repos' data instead of 'PR Reviews' data upon initial load.

<sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 162d1007a8d772a0993ddf27717a5cc4bede3dea. It will update automatically on new commits.</sup>