### PR TITLE
Update LeaderboardChart.tsx - active repos as default (take 2)

### DIFF
--- a/src/components/LeaderboardChart.tsx
+++ b/src/components/LeaderboardChart.tsx
@@ -51,7 +51,7 @@ export default function LeaderboardChart() {
   const [datePickerOpen, setDatePickerOpen] = useState<boolean>(false);
   const [toolSearchQuery, setToolSearchQuery] = useState<string>('');
   const [metric, setMetric] = useState<'active_repos' | 'pr_reviews'>(
-    'pr_reviews'
+    'active_repos'
   );
 
   const baseUrl =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Changes the default metric on the leaderboard chart from "PR Reviews" to "Active Repos".
> 
> - In `src/components/LeaderboardChart.tsx`, the default metric displayed on the chart is changed from `'pr_reviews'` to `'active_repos'`. This makes "Active Repos" the initial view when the page loads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 162d1007a8d772a0993ddf27717a5cc4bede3dea. It will update automatically on new commits.</sup>
<!-- /CURSOR_SUMMARY -->