### PR TITLE
Set default chart view to monthly

### DIFF
--- a/src/components/LeaderboardChart.tsx
+++ b/src/components/LeaderboardChart.tsx
@@ -44,7 +44,7 @@ export default function LeaderboardChart() {
 
   const debouncedDisplayDateRange = useDebounce(displayDateRange, 300);
 
-  const [viewType, setViewType] = useState<MaterializedViewType>('weekly');
+  const [viewType, setViewType] = useState<MaterializedViewType>('monthly');
   const [selectedTools, setSelectedTools] = useState<Set<number>>(new Set());
   const prevToolKeysRef = useRef<string[]>([]);
   const [scaleType, setScaleType] = useState<'linear' | 'log'>('linear');


### PR DESCRIPTION
Change the default chart view from weekly to monthly.

---
<a href="https://cursor.com/background-agent?bcId=bc-8008b239-6150-433d-b0c0-750bddb303a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8008b239-6150-433d-b0c0-750bddb303a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

