### PR TITLE
BotReviewInRepoDate to any

### DIFF
--- a/src/lib/postgres/bot_reviews_daily_by_repo.ts
+++ b/src/lib/postgres/bot_reviews_daily_by_repo.ts
@@ -19,7 +19,7 @@ export function getSql() {
  * @returns Promise<void>
  */
 export async function upsertBotReviewsForDate(
-  botReviews: BotReviewInRepoDate[],
+  botReviews: any[],
   batchSize: number = 1000
 ): Promise<void> {
   if (botReviews.length === 0) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Relaxed the type constraint for the `botReviews` parameter in the `upsertBotReviewsForDate` function from `BotReviewInRepoDate[]` to `any[]`. This change allows the function to accept a broader range of input types for bot review data.
<!-- kody-pr-summary:end -->