### PR TITLE
Set default chart view to monthly

### DIFF
--- a/src/app/api/leaderboard-reviews/route.ts
+++ b/src/app/api/leaderboard-reviews/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const viewType =
-      (searchParams.get('viewType') as MaterializedViewType) || 'weekly';
+      (searchParams.get('viewType') as MaterializedViewType) || 'monthly';
 
     // Validate viewType
     if (!['weekly', 'monthly'].includes(viewType)) {

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const viewType =
-      (searchParams.get('viewType') as MaterializedViewType) || 'weekly';
+      (searchParams.get('viewType') as MaterializedViewType) || 'monthly';
 
     // Validate viewType
     if (!['weekly', 'monthly'].includes(viewType)) {

--- a/src/components/LeaderboardChart.tsx
+++ b/src/components/LeaderboardChart.tsx
@@ -44,7 +44,7 @@ export default function LeaderboardChart() {
 
   const debouncedDisplayDateRange = useDebounce(displayDateRange, 300);
 
-  const [viewType, setViewType] = useState<MaterializedViewType>('weekly');
+  const [viewType, setViewType] = useState<MaterializedViewType>('monthly');
   const [selectedTools, setSelectedTools] = useState<Set<number>>(new Set());
   const prevToolKeysRef = useRef<string[]>([]);
   const [scaleType, setScaleType] = useState<'linear' | 'log'>('linear');

--- a/src/lib/postgres/bot_reviews_daily_by_repo.ts
+++ b/src/lib/postgres/bot_reviews_daily_by_repo.ts
@@ -123,7 +123,7 @@ export async function getMaterializedViewData(
 export async function getLeaderboardDataForDateRange(
   startDate: string,
   endDate: string,
-  viewType: MaterializedViewType = 'weekly'
+  viewType: MaterializedViewType = 'monthly'
 ): Promise<MaterializedViewData[]> {
   try {
     const data = await getMaterializedViewData(viewType, startDate, endDate);


### PR DESCRIPTION
Change the default chart view option from weekly to monthly across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd0ab951-e46d-48e5-a377-6ebfcf50c9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd0ab951-e46d-48e5-a377-6ebfcf50c9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

