### PR TITLE
[test] change type annotation 2

### DIFF
--- a/src/lib/postgres/bot_reviews_daily_by_repo.ts
+++ b/src/lib/postgres/bot_reviews_daily_by_repo.ts
@@ -19,7 +19,7 @@ export function getSql() {
  * @returns Promise<void>
  */
 export async function upsertBotReviewsForDate(
-  botReviews: BotReviewInRepoDate[],
+  botReviews: any[],
   batchSize: number = 1000
 ): Promise<void> {
   if (botReviews.length === 0) {

--- a/src/lib/postgres/bot_reviews_daily_by_repo.ts
+++ b/src/lib/postgres/bot_reviews_daily_by_repo.ts
@@ -19,7 +19,7 @@ export function getSql() {
  * @returns Promise<void>
  */
 export async function upsertBotReviewsForDate(
-  botReviews: any[],
+  botReviews: any[], // yep
   batchSize: number = 1000
 ): Promise<void> {
   if (botReviews.length === 0) {


### PR DESCRIPTION
# Original
<!-- corrupt CURSOR_SUMMARY -->
> [!NOTE]
> This PR changes the type of the `botReviews` parameter in the `upsertBotReviewsForDate` function to `any[]`.
> 
> - In `src/lib/postgres/bot_reviews_daily_by_repo.ts`, the type annotation for the `botReviews` parameter in the `upsertBotReviewsForDate` function has been changed from `BotReviewInRepoDate[]` to `any[]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92aff3233c5699aeb5a7f2c3f71b1ca5522501a3. This will update automatically on new commits.</sup>
<!-- corrupt /CURSOR_SUMMARY -->

# new model with same prompt - even more verbose wtf

<!-- corrupt CURSOR_SUMMARY -->
---

> [!NOTE]
> Loosens the `upsertBotReviewsForDate` parameter type from `BotReviewInRepoDate[]` to `any[]` without changing runtime behavior.
> 
> - **Types**:
>   - Loosen parameter type in `src/lib/postgres/bot_reviews_daily_by_repo.ts` for `upsertBotReviewsForDate` from `BotReviewInRepoDate[]` to `any[]`, affecting the `botReviews` argument only.
>   - No changes to function logic, batching, or SQL upsert behavior.
> - **Impact**:
>   - Reduces compile-time type safety for inputs to `upsertBotReviewsForDate`; no runtime behavior changes or migrations.
>   - No test updates included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92aff3233c5699aeb5a7f2c3f71b1ca5522501a3. This will update automatically on new commits.</sup>
<!-- corrupt /CURSOR_SUMMARY -->

# new model second prompt attempt - hopefully less verbose

<!-- corruptCURSOR_SUMMARY -->
---

> [!NOTE]
> Loosens the `upsertBotReviewsForDate` `botReviews` parameter type from `BotReviewInRepoDate[]` to `any[]` in `src/lib/postgres/bot_reviews_daily_by_repo.ts`.
> 
> - **Types**:
>   - Loosen `botReviews` parameter in `src/lib/postgres/bot_reviews_daily_by_repo.ts` for `upsertBotReviewsForDate` from `BotReviewInRepoDate[]` to `any[]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92aff3233c5699aeb5a7f2c3f71b1ca5522501a3. This will update automatically on new commits.</sup>
<!-- corrupt /CURSOR_SUMMARY -->

# new model third prompt attempt - hopefully less verbose

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loosens the `botReviews` parameter type in `upsertBotReviewsForDate` from `BotReviewInRepoDate[]` to `any[]` in `src/lib/postgres/bot_reviews_daily_by_repo.ts`.
> 
> - **Types**:
>   - In `src/lib/postgres/bot_reviews_daily_by_repo.ts`, change `upsertBotReviewsForDate` parameter `botReviews` type from `BotReviewInRepoDate[]` to `any[]`.
>   - No changes to batching, SQL upsert, or other functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92aff3233c5699aeb5a7f2c3f71b1ca5522501a3. This will update automatically on new commits.</sup>
<!-- /CURSOR_SUMMARY -->