### PR TITLE
Fix blog post link hover effect

### DIFF
--- a/src/components/LeaderboardRankings.tsx
+++ b/src/components/LeaderboardRankings.tsx
@@ -70,7 +70,7 @@ export function LeaderboardRankings({
             return (
               <div
                 key={tool.id}
-                className="flex flex-col p-2 rounded-lg border hover:bg-muted/50 transition-colors"
+                className="flex flex-col p-2 rounded-lg border transition-colors"
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-2 pl-2">


### PR DESCRIPTION
Remove a container hover effect in `LeaderboardRankings.tsx` to prevent all nested links from appearing hovered simultaneously.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4791f79-4be2-4f1a-826f-cbf9e4404db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4791f79-4be2-4f1a-826f-cbf9e4404db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

