### PR TITLE
[oct 17 test 21] Remove comments from parseGoogleCredentials function

### DIFF
--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -12,10 +12,6 @@ interface BigQueryRow
   pr_count: number;
 }
 
-/**
- * Parse base64-encoded Google Cloud service account credentials
- * @returns Parsed credentials object or undefined if not available
- */
 function parseGoogleCredentials(): object | undefined {
   const credentialsBase64 = process.env.GOOGLE_APPLICATION_CREDENTIALS;
   if (!credentialsBase64) {


### PR DESCRIPTION
Removed comments from the parseGoogleCredentials function.