### PR TITLE
Increase default batch size for upserting bot reviews

### DIFF
--- a/src/lib/postgres/bot_reviews_daily_by_repo.ts
+++ b/src/lib/postgres/bot_reviews_daily_by_repo.ts
@@ -20,7 +20,7 @@ export function getSql() {
  */
 export async function upsertBotReviewsForDate(
   botReviews: BotReviewInRepoDate[],
-  batchSize: number = 1000
+  batchSize: number = 2000
 ): Promise<void> {
   if (botReviews.length === 0) {
     console.log('No bot reviews to upsert');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase default upsert batch size in `upsertBotReviewsForDate` from 1000 to 2000.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59b2e3027c07f7ccb9a6135e7d23238102ee7afc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->