### PR TITLE
Ci main branch failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Install dependencies
         run: pnpm install
@@ -69,8 +67,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Remove hardcoded pnpm version from CI workflow to resolve CI failures caused by version mismatch.

The CI was failing because the GitHub Actions workflow specified `pnpm version 8`, while `package.json`'s `packageManager` field required `pnpm@10.22.0`. Removing the `version` constraint allows `pnpm/action-setup@v4` to automatically use the version defined in `package.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8756335-818e-4a89-9b90-784f3d31cfed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8756335-818e-4a89-9b90-784f3d31cfed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the hardcoded `pnpm` version from CI lint and format jobs to use the version from `packageManager`.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **pnpm Setup**: Remove `with: version: 8` from `pnpm/action-setup@v4` in `lint` and `format` jobs to rely on the version from `packageManager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e2de7e03b4f3df149ae2f9d6dd1be7e5bca3681. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->