### PR TITLE
Convert legend items into checkbox inputs

### DIFF
--- a/src/components/ui/CustomLegend.tsx
+++ b/src/components/ui/CustomLegend.tsx
@@ -28,34 +28,35 @@ export function CustomLegend({
         const opacity = isSelected ? 1 : 0.5;
 
         return (
-          <div
+          <label
             key={entry.value ?? ''}
-            className="flex items-center gap-0.5 cursor-pointer transition-opacity duration-200"
+            className="flex items-center gap-1.5 cursor-pointer transition-opacity duration-200"
             style={{ opacity }}
-            onClick={() => {
-              if (toolId) {
-                const newSelected = new Set(selectedTools);
-                if (isSelected) {
-                  newSelected.delete(toolId);
-                } else {
-                  newSelected.add(toolId);
-                }
-                setSelectedTools(newSelected);
-              }
-            }}
             title={`Click to ${isSelected ? 'hide' : 'show'} ${entry.value ?? ''}`}
           >
-            <span
-              className="inline-block w-3 h-3 sm:w-3.5 sm:h-3.5 rounded-sm border"
+            <input
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => {
+                if (toolId) {
+                  const newSelected = new Set(selectedTools);
+                  if (isSelected) {
+                    newSelected.delete(toolId);
+                  } else {
+                    newSelected.add(toolId);
+                  }
+                  setSelectedTools(newSelected);
+                }
+              }}
+              className="w-4 h-4 cursor-pointer"
               style={{
-                backgroundColor: entry.color,
-                borderColor: '#ccc',
+                accentColor: entry.color,
               }}
             />
             <span className="text-xs sm:text-sm" style={{ color: entry.color }}>
               {entry.value ?? ''}
             </span>
-          </div>
+          </label>
         );
       })}
     </div>


### PR DESCRIPTION
Make legend entries accessible and interactive by replacing the clickable div with a labeled checkbox. This change updates the layout spacing, uses an `input[type=checkbox]` with accentColor for the swatch, and moves the selection toggle logic into `onChange` so tool visibility is updated via the checkbox state. The label wrapper improves click-target and semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves legend accessibility and interaction by switching to semantic checkboxes.
> 
> - Replace clickable `div` legend items with `<label>` + `input[type="checkbox"]`, moving toggle logic to `onChange`
> - Preserve selection state via `checked` and update `selectedTools` accordingly; non-selected items reduce opacity
> - Use checkbox `accentColor` for the color swatch and adjust spacing (`gap-1.5`, larger checkbox size)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97e44e64789d4db25d5d1d459f13298aeca27add. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->