### PR TITLE
Add Augment Code bot to dashboard

### DIFF
--- a/src/devtools.json
+++ b/src/devtools.json
@@ -151,5 +151,13 @@
     "avatar_url": "https://avatars.githubusercontent.com/in/413034?v=4",
     "website_url": "https://kodus.io/",
     "brand_color": "#3b82f6"
+  },
+  {
+    "id": 185243770,
+    "account_login": "augmentcode[bot]",
+    "name": "Augment Code",
+    "avatar_url": "https://avatars.githubusercontent.com/in/1027498?v=4",
+    "website_url": "https://www.augmentcode.com",
+    "brand_color": "#968CFF"
   }
 ]


### PR DESCRIPTION
Adds Augment Code to the list of tracked AI code review tools.

**Bot details:**
- **id**: 185243770
- **account_login**: `augmentcode[bot]`
- **name**: Augment Code
- **avatar_url**: https://avatars.githubusercontent.com/in/1027498?v=4
- **website_url**: https://www.augmentcode.com
- **brand_color**: #968CFF (violet/purple from their branding)

Bot ID was retrieved using:
```bash
curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/augmentcode%5Bbot%5D"
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Augment Code to the tracked AI code review tools by appending a new entry to `src/devtools.json` for `augmentcode[bot]`.
> 
> The entry includes `id`, `account_login`, `name`, `avatar_url`, `website_url`, and `brand_color` metadata for display/usage in the dashboard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ea94282fd8b08ea0f2c256e7bea7f91dd00e570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->