### PR TITLE
Add Kilo Review bot to tracked devtools

### DIFF
--- a/src/devtools.json
+++ b/src/devtools.json
@@ -191,5 +191,13 @@
     "avatar_url": "https://avatars.githubusercontent.com/in/1027498?v=4",
     "website_url": "https://www.augmentcode.com",
     "brand_color": "#968CFF"
+  },
+  {
+    "id": 240665456,
+    "account_login": "kiloconnect[bot]",
+    "name": "Kilo Review",
+    "avatar_url": "https://avatars.githubusercontent.com/in/21937927?v=4",
+    "website_url": "https://kilocode.ai",
+    "brand_color": "#000000"
   }
 ]


### PR DESCRIPTION
Adding Kilo's Code Reviewer to tracked Devtools

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A data-only addition to the devtools registry JSON; no logic changes beyond expanding the returned list.
> 
> **Overview**
> Adds `kiloconnect[bot]` (**Kilo Review**) to `src/devtools.json`, including its GitHub app id, metadata, and brand color, so it is returned by the devtools list API and included anywhere that list is consumed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aed781e21fa14685e0e4e0742e574327a133aa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->