### PR TITLE
Add AGENTS.md with cloud-specific development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cloud-specific instructions
+
+### Overview
+
+This is a single Next.js 15 application (not a monorepo) that tracks AI code review bot adoption across open-source GitHub repos. The frontend renders a dashboard with charts; the API routes serve data from a Neon serverless Postgres database.
+
+### Key commands
+
+See `package.json` scripts and `README.md` for full details.
+
+- **Dev server**: `pnpm dev` (port 3000, uses Turbopack)
+- **Lint**: `pnpm lint`
+- **Format check**: `pnpm format:check`
+- **Format fix**: `pnpm format`
+- **Build**: `pnpm build` (requires `DATABASE_URL` for API routes that call Postgres at build time)
+
+### Environment variables
+
+Copy `.env.local.example` to `.env.local`. The `DATABASE_URL` secret is required for any API route that queries Postgres (`/api/leaderboard`, `/api/leaderboard-reviews`, `/api/top-repos`). The `/api/devtools` endpoint works without a database as it reads from `src/devtools.json`.
+
+### Database-dependent features
+
+Without a valid `DATABASE_URL`, the dashboard shows "Error: Failed to fetch data" — this is expected. The frontend still loads and interactive elements (theme toggle, links) work normally.
+
+### CI
+
+GitHub Actions runs `pnpm lint` and `pnpm format:check` on PRs. The build job is currently commented out in `.github/workflows/ci.yml`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` with cloud-specific instructions for developing in this codebase, covering:

- Key commands (dev, lint, format, build)
- Environment variable requirements
- Database-dependent feature behavior
- CI configuration notes

## Development Environment Setup

The following was verified during setup:

| Check | Command | Status |
|-------|---------|--------|
| Lint | `pnpm lint` | ✅ Pass |
| Format | `pnpm format:check` | ✅ Pass |
| Dev server | `pnpm dev` | ✅ Running on port 3000 |
| API endpoint | `GET /api/devtools` | ✅ Returns tool data |
| Theme toggle | Light/Dark/System | ✅ Working |

**Runtime**: Node.js 22.16.0, pnpm 10.22.0

**Note**: The dashboard shows "Error: Failed to fetch data" without a `DATABASE_URL` — this is expected behavior. The `/api/devtools` endpoint works without a database.


---
<p><a href="http://localhost:4000/background-agent?bcId=bc-0d085584-ea67-408c-9f12-96ddd2a664a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/agents?id=bc-0d085584-ea67-408c-9f12-96ddd2a664a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime, API, or data-handling logic is modified.
> 
> **Overview**
> Adds a new `AGENTS.md` documentation file with cloud/dev setup guidance for this Next.js app, including the primary `pnpm` commands, required `DATABASE_URL` usage and expected no-DB behavior, and a note that CI runs lint/format while the build job is currently commented out.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c04573fa1673c110ab88c04fe85e7eaaad90a50c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->