### PR TITLE
Add new 100-line stub file

### DIFF
--- a/src/lib/generated_stub.ts
+++ b/src/lib/generated_stub.ts
@@ -1,5 +1,5 @@
 // Auto-generated stub file with placeholder implementation.
-export type StubState = "idle" | "running" | "completed";
+export type StubState = 'idle' | 'running' | 'completed';
 
 export interface StubRecord {
   id: string;

--- a/src/lib/generated_stub.ts
+++ b/src/lib/generated_stub.ts
@@ -1,0 +1,100 @@
+// Auto-generated stub file with placeholder implementation.
+export type StubState = "idle" | "running" | "completed";
+
+export interface StubRecord {
+  id: string;
+  label: string;
+  enabled: boolean;
+}
+
+export interface StubRepository {
+  list(): Promise<StubRecord[]>;
+  getById(id: string): Promise<StubRecord | null>;
+  save(record: StubRecord): Promise<void>;
+  remove(id: string): Promise<void>;
+}
+
+export class InMemoryStubRepository implements StubRepository {
+  private readonly records = new Map<string, StubRecord>();
+
+  async list(): Promise<StubRecord[]> {
+    return Array.from(this.records.values());
+  }
+
+  async getById(id: string): Promise<StubRecord | null> {
+    return this.records.get(id) ?? null;
+  }
+
+  async save(record: StubRecord): Promise<void> {
+    this.records.set(record.id, record);
+  }
+
+  async remove(id: string): Promise<void> {
+    this.records.delete(id);
+  }
+}
+
+export function createStubRecord(id: string): StubRecord {
+  return {
+    id,
+    label: `stub-${id}`,
+    enabled: false,
+  };
+}
+
+// TODO: Replace this stub with a real data source.
+// TODO: Validate IDs before persisting records.
+// TODO: Add schema validation for label length.
+// TODO: Enforce uniqueness constraints across stores.
+// TODO: Attach audit timestamps to saved records.
+// TODO: Add optimistic concurrency safeguards.
+// TODO: Add pagination options for list queries.
+// TODO: Add filtering by label and enabled flag.
+// TODO: Add sorting controls for deterministic output.
+// TODO: Move to server-backed persistence layer.
+// TODO: Add cache invalidation hooks for updates.
+// TODO: Add retry behavior for transient failures.
+// TODO: Add tracing spans around repository calls.
+// TODO: Add metrics for read/write operation counts.
+// TODO: Add circuit breaker for downstream outages.
+// TODO: Define and document repository error types.
+// TODO: Add unit tests for CRUD behavior.
+// TODO: Add integration tests for persistence adapter.
+// TODO: Add test fixture builders for StubRecord.
+// TODO: Add benchmark cases for large record sets.
+// TODO: Document migration strategy from this stub.
+// TODO: Add ownership metadata to each record.
+// TODO: Add soft-delete support with restore APIs.
+// TODO: Add bulk insert and bulk delete methods.
+// TODO: Add validation for forbidden label characters.
+// TODO: Add rate limiting at repository boundaries.
+// TODO: Add deterministic seed data for local demos.
+// TODO: Add serialization helpers for transport.
+// TODO: Add deserialization guards for untrusted input.
+// TODO: Add compatibility layer for legacy IDs.
+// TODO: Add migration tooling for historical records.
+// TODO: Add backup and restore support hooks.
+// TODO: Add support for partial field updates.
+// TODO: Add API docs with examples and caveats.
+// TODO: Add access control checks per operation.
+// TODO: Add tenant scoping for multi-tenant usage.
+// TODO: Add environment-based feature flags.
+// TODO: Add smoke tests for production readiness.
+// TODO: Add contract tests for adapter conformance.
+// TODO: Add fault-injection tests for resilience.
+// TODO: Add dead-letter handling for failed writes.
+// TODO: Add idempotency handling for retry safety.
+// TODO: Add data retention policy enforcement.
+// TODO: Add archival pipeline for old records.
+// TODO: Add observability dashboards and alerts.
+// TODO: Add ownership handoff notes for maintainers.
+// TODO: Add startup data integrity checks.
+// TODO: Add shutdown hooks to flush pending writes.
+// TODO: Add reconciliation job for drift detection.
+// TODO: Add repair tooling for corrupt records.
+// TODO: Add compatibility tests across runtimes.
+// TODO: Add stricter TypeScript compiler checks.
+// TODO: Add lint rules specific to repository layer.
+// TODO: Add code generation for repetitive adapters.
+// TODO: Add template for future repository variants.
+// TODO: Add changelog entries for interface changes.


### PR DESCRIPTION
## Summary
- Add `src/lib/generated_stub.ts` as a new TypeScript stub module.
- Keep the file at exactly 100 lines.
- Apply Prettier formatting so CI format checks pass.

## Testing
- `pnpm run format:check` passes locally.
- `wc -l src/lib/generated_stub.ts` returns `100`.
- Verified clean working tree after commit/push.