### PR TITLE
Set main page background to red

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,7 @@ Without a valid `DATABASE_URL`, the dashboard shows "Error: Failed to fetch data
 ### CI
 
 GitHub Actions runs `pnpm lint` and `pnpm format:check` on PRs. The build job is currently commented out in `.github/workflows/ci.yml`.
+
+### Pull requests (`ManagePullRequest`)
+
+When creating or updating PRs with the ManagePullRequest tool: **do not** copy walkthrough screenshots into `public/` or commit other image assets just so the PR description can show an `<img>`. That is unnecessary. Use a URL GitHub can load without adding files to the repo (for example an image uploaded in the GitHub PR/issue UI, which yields a `user-images.githubusercontent.com` URL), or omit the image from the automated PR body and add it manually.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,3 @@ Without a valid `DATABASE_URL`, the dashboard shows "Error: Failed to fetch data
 ### CI
 
 GitHub Actions runs `pnpm lint` and `pnpm format:check` on PRs. The build job is currently commented out in `.github/workflows/ci.yml`.
-
-### Pull requests (`ManagePullRequest`)
-
-When creating or updating PRs with the ManagePullRequest tool: **do not** copy walkthrough screenshots into `public/` or commit other image assets just so the PR description can show an `<img>`. That is unnecessary. Use a URL GitHub can load without adding files to the repo (for example an image uploaded in the GitHub PR/issue UI, which yields a `user-images.githubusercontent.com` URL), or omit the image from the automated PR body and add it manually.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,8 +45,8 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background: oklch(0.55 0.22 27);
+  --foreground: oklch(0.985 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -79,7 +79,7 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.55 0.22 27);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
[Red main page background](https://cursor.com/agents/bc-b60c6b2c-4541-4c5c-8cbc-7d198dc458f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmain_background_red.png)

## Summary
- Updates `--background` in `globals.css` for light and dark themes so the main page uses a red background (via `body` `bg-background`).
- Adjusts light-mode `--foreground` to light text for contrast on the red background.

## Testing
- `pnpm lint` passes.
- `pnpm format:check` reports pre-existing `package.json` formatting (unchanged by this PR).
- Manual: dev server + screenshot of localhost showing red main background (see image above).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b60c6b2c-4541-4c5c-8cbc-7d198dc458f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b60c6b2c-4541-4c5c-8cbc-7d198dc458f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

