### PR TITLE
Set app background color to red

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,8 +45,8 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background: oklch(0.55 0.24 27);
+  --foreground: oklch(0.99 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -79,8 +79,8 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
+  --background: oklch(0.55 0.24 27);
+  --foreground: oklch(0.99 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the global `--background` CSS variable in `src/app/globals.css` so the page uses a red background in both light and dark themes. Adjusts `--foreground` in `:root` to near-white for contrast on the red canvas.

## Testing

- `pnpm lint` passes.
- Manual browser check: dashboard loads with a red background behind the main content.

<a href="https://cursor.com/agents/bc-86b6c44a-bcf1-479a-8ebe-241add82e3d5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fred_background_dashboard.mp4"><img src="https://cursor.com/artifacts/c/art-972e3c05-aec9-4470-a241-57b4fa220cd0" alt="red_background_dashboard.mp4" /></a>

![Dashboard with red background](https://cursor.com/artifacts/c/art-7faa3449-391a-4454-bc93-1e5a55779fb2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86b6c44a-bcf1-479a-8ebe-241add82e3d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86b6c44a-bcf1-479a-8ebe-241add82e3d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

