### PR TITLE
docs: add cloud agent setup gotchas to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,9 @@ Without a valid `DATABASE_URL`, the dashboard shows "Error: Failed to fetch data
 ### CI
 
 GitHub Actions runs `pnpm lint` and `pnpm format:check` on PRs. The build job is currently commented out in `.github/workflows/ci.yml`.
+
+### Gotchas
+
+- `.env.local.example` sets `NODE_ENV="production"`. The dev server will emit a warning about non-standard `NODE_ENV`; this is harmless and can be ignored.
+- `pnpm format:check` currently fails on `package.json` upstream. This is a pre-existing issue, not caused by local changes.
+- pnpm 10+ warns about ignored build scripts (`@tailwindcss/oxide`, `esbuild`, etc.). The dev server and lint still work without running those build scripts.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds non-obvious setup gotchas to `AGENTS.md` under `## Cursor Cloud specific instructions` discovered during environment setup:

- `NODE_ENV="production"` warning from the `.env.local.example` template is harmless
- `pnpm format:check` pre-existing failure on `package.json` upstream
- pnpm 10+ build script warnings are safe to ignore for dev/lint

### Environment setup verified

| Check | Result |
|---|---|
| `pnpm lint` | No warnings or errors |
| `pnpm format:check` | Pre-existing `package.json` format issue (upstream) |
| `pnpm dev` | Dev server starts on port 3000, frontend loads |
| `/api/devtools` | Returns JSON data without database |
| Theme toggle | Light/dark mode works |

### Demo

<a href="https://cursor.com/agents/bc-0bce330b-37e0-4994-a448-ee0f17efbf02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_dashboard_interaction.mp4"><img src="https://cursor.com/artifacts/c/art-8e3d33e7-1862-4f34-b4e8-59091d43d89e" alt="demo_dashboard_interaction.mp4" /></a>

Dashboard loading with theme toggle interaction (light/dark mode).

![Dashboard in light mode](https://cursor.com/artifacts/c/art-5ccd3955-9cf2-4ab9-b392-c56141941c71)
![Dashboard in dark mode](https://cursor.com/artifacts/c/art-bac7f07f-4485-4321-954b-008cb225e4b4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bce330b-37e0-4994-a448-ee0f17efbf02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bce330b-37e0-4994-a448-ee0f17efbf02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

