### PR TITLE
docs: add gotchas section to AGENTS.md for cloud agent setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,11 @@ Copy `.env.local.example` to `.env.local`. The `DATABASE_URL` secret is required
 
 Without a valid `DATABASE_URL`, the dashboard shows "Error: Failed to fetch data" — this is expected. The frontend still loads and interactive elements (theme toggle, links) work normally.
 
+### Gotchas
+
+- `pnpm install` emits a warning about ignored build scripts (`@tailwindcss/oxide`, `esbuild`, `sharp`, etc.). The dev server works fine without them—pnpm downloads pre-built binaries. Do not run `pnpm approve-builds` (it is interactive).
+- `pnpm format:check` fails on a pre-existing formatting issue in `package.json`. This is not caused by your changes.
+
 ### CI
 
 GitHub Actions runs `pnpm lint` and `pnpm format:check` on PRs. The build job is currently commented out in `.github/workflows/ci.yml`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a "Gotchas" section to AGENTS.md documenting two non-obvious issues that future cloud agents will encounter during setup:

1. `pnpm install` emits a warning about ignored build scripts — the dev server works fine without them.
2. `pnpm format:check` fails on a pre-existing formatting issue in `package.json` that is not caused by agent changes.

These notes prevent future agents from wasting time investigating benign warnings/failures.

---

**Environment setup verified:**

[demo_dashboard_interaction.mp4](https://cursor.com/agents/bc-6d480c7e-e995-473c-91b7-f9f57ebbff28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_dashboard_interaction.mp4)

Dashboard loads, theme toggle works, and API endpoints respond correctly.

[Dashboard light mode](https://cursor.com/agents/bc-6d480c7e-e995-473c-91b7-f9f57ebbff28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_light_mode.webp)
[Dashboard dark mode](https://cursor.com/agents/bc-6d480c7e-e995-473c-91b7-f9f57ebbff28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_dark_mode.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-6d480c7e-e995-473c-91b7-f9f57ebbff28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-6d480c7e-e995-473c-91b7-f9f57ebbff28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

