### PR TITLE
docs: add Cloud Agent VM development notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,9 @@ Without a valid `DATABASE_URL`, the dashboard shows "Error: Failed to fetch data
 ### CI
 
 GitHub Actions runs `pnpm lint` and `pnpm format:check` on PRs. The build job is currently commented out in `.github/workflows/ci.yml`.
+
+### Cloud Agent VM notes
+
+- If `DATABASE_URL` is available as an environment secret, write it to `.env.local` (Next.js loads env from that file in dev): `printf 'DATABASE_URL="%s"\n' "$DATABASE_URL" > .env.local`
+- Cloud VMs may set `NODE_ENV=production` globally; `pnpm dev` will warn but still runs.
+- Do not run `pnpm build` while `pnpm dev` is running — both use `.next` and the dev server will break until restarted.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Cloud Agent VM-specific notes to `AGENTS.md` discovered during environment setup:

- How to wire `DATABASE_URL` from environment secrets into `.env.local`
- `NODE_ENV=production` warning in cloud VMs during `pnpm dev`
- Avoid running `pnpm build` while `pnpm dev` is active (`.next` conflict)

## Environment verification

Dev environment was set up and verified:

- `pnpm install` — dependencies installed
- `pnpm dev` — Next.js 15 dev server on port 3000
- `pnpm lint` — passes
- `pnpm build` — succeeds with `DATABASE_URL` configured
- Dashboard loads; theme toggle works; `/api/devtools` returns bot data

<a href="https://cursor.com/agents/bc-662e4eed-a906-46dd-bf07-4b72a1996ba5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_dev_environment_demo.mp4"><img src="https://cursor.com/artifacts/c/art-88d0d105-1714-4a06-9737-6508ebd211a0" alt="dashboard_dev_environment_demo.mp4" /></a>

![Dashboard in light mode](https://cursor.com/artifacts/c/art-0ea88d76-bf22-4d9d-aaf4-ef5639d370c9)
![Dashboard in dark mode](https://cursor.com/artifacts/c/art-efd4e2ce-6db2-4c04-b73d-0be29b4b6fba)
![Devtools API JSON response](https://cursor.com/artifacts/c/art-5a753736-ff5d-4992-954c-99c73dff6373)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-662e4eed-a906-46dd-bf07-4b72a1996ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-662e4eed-a906-46dd-bf07-4b72a1996ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

