### PR TITLE
docs: improve cloud agent dev environment guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,15 @@ See `package.json` scripts and `README.md` for full details.
 
 Copy `.env.local.example` to `.env.local`. The `DATABASE_URL` secret is required for any API route that queries Postgres (`/api/leaderboard`, `/api/leaderboard-reviews`, `/api/top-repos`). The `/api/devtools` endpoint works without a database as it reads from `src/devtools.json`.
 
+If you do not have a real `DATABASE_URL`, comment out or remove that line in `.env.local`. The example placeholder hostname (`host`) causes API routes to return HTTP 500 instead of the graceful frontend fetch error.
+
 ### Database-dependent features
 
 Without a valid `DATABASE_URL`, the dashboard shows "Error: Failed to fetch data" — this is expected. The frontend still loads and interactive elements (theme toggle, links) work normally.
+
+### Runtime versions
+
+Node.js 22+ and pnpm 10.22.0 (see `.node-version`, `.mise.toml`, and `packageManager` in `package.json`). The dev server runs on port 3000.
 
 ### CI
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents two gotchas discovered during cloud VM dev environment setup:

- Comment out the example `DATABASE_URL` placeholder when no real database is configured (avoids HTTP 500 from invalid hostname)
- Notes expected Node.js 22+ / pnpm 10.22.0 runtime versions

## Walkthrough

Dev environment was verified end-to-end on the cloud VM:

[dashboard_dev_env_demo.mp4](https://cursor.com/agents/bc-6ad91bf6-5488-4fac-94a1-1749fea0c6c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_dev_env_demo.mp4)
Dashboard loads, theme toggle works, and `/api/devtools` returns bot data.

[Dashboard light mode](https://cursor.com/agents/bc-6ad91bf6-5488-4fac-94a1-1749fea0c6c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_dashboard_light.webp)
[Dashboard dark mode](https://cursor.com/agents/bc-6ad91bf6-5488-4fac-94a1-1749fea0c6c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_dashboard_dark.webp)
[Devtools API JSON](https://cursor.com/agents/bc-6ad91bf6-5488-4fac-94a1-1749fea0c6c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_api_devtools.webp)

## Testing

- ✅ `pnpm install`
- ✅ `pnpm lint`
- ⚠️ `pnpm format:check` (pre-existing failure in `package.json`)
- ✅ `pnpm build`
- ✅ `pnpm dev` (port 3000)
- ✅ Manual browser test of dashboard, theme toggle, and `/api/devtools`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-6ad91bf6-5488-4fac-94a1-1749fea0c6c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-6ad91bf6-5488-4fac-94a1-1749fea0c6c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

