### PR TITLE
fix: replace failing test stub with pnpm install in environment.json

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-  "install": "echo 'testing install script' && exit 1"
+  "install": "pnpm install"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `.cursor/environment.json` install script was set to a test stub that always exits with code 1:

```json
{ "install": "echo 'testing install script' && exit 1" }
```

This caused every cloud agent pod startup to report a failed install script. Replaced with the actual install command:

```json
{ "install": "pnpm install" }
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-fa2f75ab-ec78-48c0-bc86-667daaa73ecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-fa2f75ab-ec78-48c0-bc86-667daaa73ecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

