### PR TITLE
fix: restore pnpm install in environment.json

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-  "install": "echo 'testing install script' && exit 1"
+  "install": "pnpm install"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`.cursor/environment.json` contained a broken stub install script:

```json
{ "install": "echo 'testing install script' && exit 1" }
```

This caused every cloud agent pod started from `main` to fail its install step with exit code 1. At least 3 previous agents diagnosed and attempted to fix this, but their fixes were on unmerged feature branches — so `main` kept spawning broken environments.

## Fix

Restore the install script to `pnpm install`:

```json
{ "install": "pnpm install" }
```

## Verification

`ReplaceEnv` confirmed `pnpm install` ran successfully (exit code 0) on a fresh pod.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-4370d3d7-219e-488b-9d35-a702bc9dd8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-4370d3d7-219e-488b-9d35-a702bc9dd8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

