### PR TITLE
fix: replace broken install script stub with pnpm install

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-  "install": "echo 'testing install script' && exit 1"
+  "install": "pnpm install"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `.cursor/environment.json` install script was a non-functional test stub that always exited with code 1:

```json
{
  "install": "echo 'testing install script' && exit 1"
}
```

This caused every cloud agent pod startup to fail during the install phase, meaning no dependencies were ever installed. All cloud agents on this repository were affected — five consecutive environment-doctor runs confirmed the same root cause.

## Fix

Replace the broken stub with the correct install command for this pnpm-based Next.js project:

```json
{
  "install": "pnpm install"
}
```

## Verification

- `pnpm install` now runs successfully on pod startup (exit code 0, 790 packages installed in ~6.6s)
- `pnpm lint` passes cleanly after the fix
- `ReplaceEnv` with the updated config confirmed the new install command runs correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-05b18342-3923-46d9-bb63-c7200892981a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-05b18342-3923-46d9-bb63-c7200892981a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

